### PR TITLE
WIP: workspace idea (do not merge!)

### DIFF
--- a/nef/nef_theano/test_workspace.py
+++ b/nef/nef_theano/test_workspace.py
@@ -84,7 +84,7 @@ class MergeableGraph(unittest.TestCase, StdMixins):
 
     def test_merged(self):
         ws, ws_shrd = self.foo[2:]
-        assert len(ws.vals_memo) == 2
+        assert len(ws.vals_memo) == self.n_groups
         assert len(ws_shrd.vals_memo) == 1
 
     def test_computation_merged(self):

--- a/nef/nef_theano/test_workspace.py
+++ b/nef/nef_theano/test_workspace.py
@@ -49,17 +49,12 @@ def test_merge_1():
     ws_opt = SharedStorageWorkspace(ws)
     f_opt = ws_opt.compiled_updates['f']
 
-    print f_opt.order
+    assert len(ws.vals_memo) == 2
+    assert len(ws_opt.vals_memo) == 1
 
-    assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
-    ws.run_update('f')
-    assert np.allclose([ws[x], ws[y]],[[2, 4], [6, 8]])
-    ws.run_update('f')
-    assert np.allclose([ws[x], ws[y]],[[4, 8], [12, 16]])
-
-    assert np.allclose([ws_opt[x], ws_opt[y]],[[1, 2], [3, 4]])
-    ws_opt.run_update('f')
-    assert np.allclose([ws_opt[x], ws_opt[y]],[[2, 4], [6, 8]])
-    ws_opt.run_update('f')
-    assert np.allclose([ws_opt[x], ws_opt[y]],[[4, 8], [12, 16]])
-
+    for w in (ws, ws_opt):
+        assert np.allclose([w[x], w[y]],[[1, 2], [3, 4]])
+        w.run_update('f')
+        assert np.allclose([w[x], w[y]],[[2, 4], [6, 8]])
+        w.run_update('f')
+        assert np.allclose([w[x], w[y]],[[4, 8], [12, 16]])

--- a/nef/nef_theano/test_workspace.py
+++ b/nef/nef_theano/test_workspace.py
@@ -1,0 +1,23 @@
+import numpy as np
+from theano import tensor
+from workspace import Workspace
+
+def test_basic_1():
+
+
+    x = tensor.vector('x')
+    y = tensor.vector('y')
+
+    ws = Workspace()
+    ws[x] = [1, 2]
+    ws[y] = [3, 4]
+    ws.compile_update('f', [
+        (x, 2 * x),
+        (y, x + y)])
+    
+    assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+    ws.run_update('f')
+    assert np.allclose([ws[x], ws[y]],[[2, 4], [4, 6]])
+    ws.run_update('f')
+    assert np.allclose([ws[x], ws[y]],[[4, 8], [6, 10]])
+

--- a/nef/nef_theano/test_workspace.py
+++ b/nef/nef_theano/test_workspace.py
@@ -29,11 +29,11 @@ class SimpleGraph(unittest.TestCase, StdMixins):
     def tearDown(self):
         x, y, ws = self.foo
 
-        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]]), (ws[x], ws[y])
         ws.run_update('f')
-        assert np.allclose([ws[x], ws[y]],[[2, 4], [4, 6]])
+        assert np.allclose([ws[x], ws[y]],[[2, 4], [4, 6]]), (ws[x], ws[y])
         ws.run_update('f')
-        assert np.allclose([ws[x], ws[y]],[[4, 8], [6, 10]])
+        assert np.allclose([ws[x], ws[y]],[[4, 8], [6, 10]]), (ws[x], ws[y])
 
 
 class SwapGraph(unittest.TestCase, StdMixins):
@@ -49,11 +49,11 @@ class SwapGraph(unittest.TestCase, StdMixins):
 
     def tearDown(self):
         x, y, ws = self.foo
-        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]]), (ws[x], ws[y])
         ws.run_update('f')
-        assert np.allclose([ws[x], ws[y]],[[3, 4], [1, 2]])
+        assert np.allclose([ws[x], ws[y]],[[3, 4], [1, 2]]), (ws[x], ws[y])
         ws.run_update('f')
-        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]]), (ws[x], ws[y])
 
 
 class MergeableGraph(unittest.TestCase, StdMixins):

--- a/nef/nef_theano/test_workspace.py
+++ b/nef/nef_theano/test_workspace.py
@@ -1,60 +1,89 @@
+import unittest
 import numpy as np
 import theano
 from theano import tensor
 from workspace import Workspace, SharedStorageWorkspace
 
-def test_basic_1():
-    x = tensor.vector('x')
-    y = tensor.vector('y')
+class StdMixins(object):
+    def test_scaffolding(self):
+        pass
 
-    ws = Workspace()
-    ws[x] = [1, 2]
-    ws[y] = [3, 4]
-    ws.compile_update('f', [
-        (x, 2 * x),
-        (y, x + y)])
-
-    assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
-    ws.run_update('f')
-    assert np.allclose([ws[x], ws[y]],[[2, 4], [4, 6]])
-    ws.run_update('f')
-    assert np.allclose([ws[x], ws[y]],[[4, 8], [6, 10]])
+    def test_optimize(self):
+        ws = self.foo[2]
+        ws.optimize('fast_run')
+        theano.printing.debugprint(ws.compiled_updates['f'].ufgraph.fgraph.outputs)
 
 
-def test_no_alias():
-    x = tensor.vector('x')
-    y = tensor.vector('y')
+class SimpleGraph(unittest.TestCase, StdMixins):
+    def setUp(self):
+        x = tensor.vector('x')
+        y = tensor.vector('y')
 
-    ws = Workspace()
-    ws[x] = [1, 2]
-    ws[y] = [3, 4]
-    ws.compile_update('f', [(x, y), (y, x)])
+        ws = Workspace()
+        ws[x] = [1, 2]
+        ws[y] = [3, 4]
+        ws.compile_update('f', [
+            (x, 2 * x),
+            (y, x + y)])
+        self.foo = x, y, ws
 
-    assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
-    ws.run_update('f')
-    assert np.allclose([ws[x], ws[y]],[[3, 4], [1, 2]])
-    ws.run_update('f')
-    assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+    def tearDown(self):
+        x, y, ws = self.foo
+
+        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+        ws.run_update('f')
+        assert np.allclose([ws[x], ws[y]],[[2, 4], [4, 6]])
+        ws.run_update('f')
+        assert np.allclose([ws[x], ws[y]],[[4, 8], [6, 10]])
 
 
-def test_merge_1():
-    x = tensor.vector('x')
-    y = tensor.vector('y')
+class SwapGraph(unittest.TestCase, StdMixins):
+    def setUp(self):
+        x = tensor.vector('x')
+        y = tensor.vector('y')
 
-    ws = Workspace()
-    ws[x] = [1, 2]
-    ws[y] = [3, 4]
-    f = ws.compile_update('f', [(x, 2 * x), (y, 2 * y)])
+        ws = Workspace()
+        ws[x] = [1, 2]
+        ws[y] = [3, 4]
+        ws.compile_update('f', [(x, y), (y, x)])
+        self.foo = x, y, ws
 
-    ws_opt = SharedStorageWorkspace(ws)
-    f_opt = ws_opt.compiled_updates['f']
+    def tearDown(self):
+        x, y, ws = self.foo
+        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+        ws.run_update('f')
+        assert np.allclose([ws[x], ws[y]],[[3, 4], [1, 2]])
+        ws.run_update('f')
+        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
 
-    assert len(ws.vals_memo) == 2
-    assert len(ws_opt.vals_memo) == 1
 
-    for w in (ws, ws_opt):
-        assert np.allclose([w[x], w[y]],[[1, 2], [3, 4]])
-        w.run_update('f')
-        assert np.allclose([w[x], w[y]],[[2, 4], [6, 8]])
-        w.run_update('f')
-        assert np.allclose([w[x], w[y]],[[4, 8], [12, 16]])
+class MergeableGraph(unittest.TestCase, StdMixins):
+    def setUp(self):
+
+        x = tensor.vector('x')
+        y = tensor.vector('y')
+
+        ws = Workspace()
+        ws[x] = [1, 2]
+        ws[y] = [3, 4]
+        f = ws.compile_update('f', [(x, 2 * x), (y, 2 * y)])
+
+        ws_opt = SharedStorageWorkspace(ws)
+        f_opt = ws_opt.compiled_updates['f']
+        self.foo = x, y, ws, ws_opt
+
+    def tearDown(self):
+        x, y, ws, ws_opt = self.foo
+
+        for w in (ws, ws_opt):
+            assert np.allclose([w[x], w[y]],[[1, 2], [3, 4]])
+            w.run_update('f')
+            assert np.allclose([w[x], w[y]],[[2, 4], [6, 8]])
+            w.run_update('f')
+            assert np.allclose([w[x], w[y]],[[4, 8], [12, 16]])
+
+    def test_merged(self):
+        ws, ws_opt = self.foo[2:]
+        assert len(ws.vals_memo) == 2
+        assert len(ws_opt.vals_memo) == 1
+

--- a/nef/nef_theano/test_workspace.py
+++ b/nef/nef_theano/test_workspace.py
@@ -6,7 +6,7 @@ from workspace import Workspace, SharedStorageWorkspace
 
 class StdMixins(object):
     def test_scaffolding(self):
-        pass
+        theano.printing.debugprint(self.foo[2].compiled_updates['f'].ufgraph.fgraph.outputs)
 
     def test_optimize(self):
         ws = self.foo[2]
@@ -49,6 +49,10 @@ class SwapGraph(unittest.TestCase, StdMixins):
 
     def tearDown(self):
         x, y, ws = self.foo
+        assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]]), (ws[x], ws[y])
+        ws.run_update('f')
+        assert np.allclose([ws[x], ws[y]],[[3, 4], [1, 2]]), (ws[x], ws[y])
+        ws.run_update('f')
         assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]]), (ws[x], ws[y])
         ws.run_update('f')
         assert np.allclose([ws[x], ws[y]],[[3, 4], [1, 2]]), (ws[x], ws[y])

--- a/nef/nef_theano/test_workspace.py
+++ b/nef/nef_theano/test_workspace.py
@@ -1,10 +1,9 @@
 import numpy as np
+import theano
 from theano import tensor
-from workspace import Workspace
+from workspace import Workspace, SharedStorageWorkspace
 
 def test_basic_1():
-
-
     x = tensor.vector('x')
     y = tensor.vector('y')
 
@@ -14,10 +13,53 @@ def test_basic_1():
     ws.compile_update('f', [
         (x, 2 * x),
         (y, x + y)])
-    
+
     assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
     ws.run_update('f')
     assert np.allclose([ws[x], ws[y]],[[2, 4], [4, 6]])
     ws.run_update('f')
     assert np.allclose([ws[x], ws[y]],[[4, 8], [6, 10]])
+
+
+def test_no_alias():
+    x = tensor.vector('x')
+    y = tensor.vector('y')
+
+    ws = Workspace()
+    ws[x] = [1, 2]
+    ws[y] = [3, 4]
+    ws.compile_update('f', [(x, y), (y, x)])
+
+    assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+    ws.run_update('f')
+    assert np.allclose([ws[x], ws[y]],[[3, 4], [1, 2]])
+    ws.run_update('f')
+    assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+
+
+def test_merge_1():
+    x = tensor.vector('x')
+    y = tensor.vector('y')
+
+    ws = Workspace()
+    ws[x] = [1, 2]
+    ws[y] = [3, 4]
+    f = ws.compile_update('f', [(x, 2 * x), (y, 2 * y)])
+
+    ws_opt = SharedStorageWorkspace(ws)
+    f_opt = ws_opt.compiled_updates['f']
+
+    print f_opt.order
+
+    assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])
+    ws.run_update('f')
+    assert np.allclose([ws[x], ws[y]],[[2, 4], [6, 8]])
+    ws.run_update('f')
+    assert np.allclose([ws[x], ws[y]],[[4, 8], [12, 16]])
+
+    assert np.allclose([ws_opt[x], ws_opt[y]],[[1, 2], [3, 4]])
+    ws_opt.run_update('f')
+    assert np.allclose([ws_opt[x], ws_opt[y]],[[2, 4], [6, 8]])
+    ws_opt.run_update('f')
+    assert np.allclose([ws_opt[x], ws_opt[y]],[[4, 8], [12, 16]])
 

--- a/nef/nef_theano/test_workspace.py
+++ b/nef/nef_theano/test_workspace.py
@@ -128,8 +128,11 @@ class MergeGraph(unittest.TestCase, StdMixins):
 class MergeGraph5(MergeGraph):
     n_groups = 5
 
-
-class MergeGraph26(MergeGraph):
-    n_items = 1000
+class MergeGraph26_50(MergeGraph):
     n_groups = 26
+    n_items = 50
+
+class MergeGraph26_1000(MergeGraph):
+    n_groups = 26
+    n_items = 1000
 

--- a/nef/nef_theano/workspace.py
+++ b/nef/nef_theano/workspace.py
@@ -6,6 +6,7 @@ import numpy as np
 import theano
 from theano.gof.vm import VM_Linker
 from theano.compile import deep_copy_op
+from theano.compile.function_module import infer_reuse_pattern
 from theano.compile.pfunc import rebuild_collect_shared
 
 
@@ -120,8 +121,9 @@ class CompiledUpdate(object):
 
         # -- create a VM to run the updates
         #    XXX CVM is necessary here until LoopGC implements updates
-        linker = VM_Linker(use_cloop=True, **VM_Linker_kwargs)
-        linker.accept(ufgraph.fgraph, no_recycling=[])
+        linker = VM_Linker(use_cloop=False, allow_gc=False, **VM_Linker_kwargs)
+        no_recycling = infer_reuse_pattern(ufgraph.fgraph, ufgraph.fgraph.outputs)
+        linker.accept(ufgraph.fgraph, no_recycling=no_recycling)
         linker.accept_var_updates(dict(zip(
             ufgraph.cloned_dests,
             ufgraph.cloned_outputs)))

--- a/nef/nef_theano/workspace.py
+++ b/nef/nef_theano/workspace.py
@@ -1,0 +1,135 @@
+import sys
+
+import theano
+from theano.gof.vm import VM_Linker
+
+class CompiledUpdate(object):
+    def __init__(self, updated_vars, vals_memo, profiler=None,
+              **VM_Linker_kwargs):
+        """
+        updated_vars: sequence of (dst, expr) pairs
+
+        allow_gc - force the virtual machine to clean up unnecessary references,
+            in order to allow garbage collection on intermediate values during
+            computation of a function.
+
+        use_cloop - use the C-based virtual machine if possible
+
+        callback - a callable object to call after each call to a thunk within
+            the virtual machine.  It will be called with four arguments called
+            'node', 'thunk', 'storage_map', and 'compute_map'.
+
+        This object does *NOT* clone the expression graph, nor does it modify
+        the expression graph.
+
+        # XXX currently it does modify the expression graph because it creates an FGraph
+        # instance, but it should be changed to avoid this, because all it really needs
+        # the fgraph for is sorting.
+
+        """
+
+        dests, outputs = zip(*updated_vars)
+        inputs = theano.gof.graph.inputs(outputs + dests)
+        fgraph = theano.gof.FunctionGraph(inputs, outputs)
+
+        #print 'inputs'
+        #theano.printing.debugprint(inputs)
+        #print 'outputs'
+        #theano.printing.debugprint(outputs)
+
+        linker = VM_Linker(**VM_Linker_kwargs)
+        linker.accept(fgraph, no_recycling=[])
+        linker.accept_var_updates(dict(updated_vars))
+
+        input_storage = [vals_memo[i] if i in vals_memo else [i.data]
+                for i in inputs]
+        output_storage = [vals_memo[i] if i in vals_memo else [None]
+                for i in dests] # CAREFUL IS THIS OK?
+
+        vm, input_containers, output_containers, thunks, order = linker.make_all(
+            profiler=profiler,
+            input_storage=input_storage,
+            output_storage=output_storage)
+
+        self.inputs = inputs
+        self.outputs = outputs
+        self.fgraph = fgraph
+        self.vm = vm
+        self.input_storage = input_storage
+        self.output_storage = output_storage
+        self.input_containers = input_containers
+        self.output_containers = output_containers
+        self.thynks = thunks
+        self.order = order
+
+    def __call__(self):
+        # if profiler then we need to update it (see function_module.py:641)
+        return self.vm()
+
+
+class Workspace(object):
+    """
+    """
+
+    def __init__(self ):
+        self.vals_memo = {}
+        self.compiled_updates = {}
+
+    def __contains__(self, key):
+        return key in self.vals_memo
+
+    def __getitem__(self, key):
+        return self.vals_memo[key][0]
+
+    def __setitem__(self, key, val):
+        filtered_val = key.type.filter(val, strict=False, allow_downcast=True)
+        if key in self.vals_memo:
+            self.vals_memo[key][0] = filtered_val
+        else:
+            self.vals_memo[key] = [filtered_val]
+
+    def compile_update(self, key, updated_vars):
+        """
+
+        Return a function that will update this workspaces
+        values for keys according to `exprs`
+
+        """
+        cu = CompiledUpdate(updated_vars, self.vals_memo)
+        self.compiled_updates[key] = cu
+        return cu
+
+    def run_update(self, key):
+        self.compiled_updates[key]()
+
+    def optimize_memory_layout(self):
+        """
+        Potentially optimize the internal physical memory layout of variables
+        in order to run the compiled_updates faster.
+
+        This function generally invalidates any views into memory associated
+        with variables.
+        """
+        pass
+
+
+class Function(Workspace):
+    """
+    Special case of Workspace for implementing a single callable expression
+    """
+    def __init__(self, inputs, outputs):
+        self._inputs = inputs
+        self._outputs = outputs
+        self._dests = [o.type() for o in outputs]
+        for var in self._inputs + _self.dests:
+            self[var] = None
+        self.add_compiled_update('__call__', zip(self._dests, self._outputs))
+
+    def __call__(self, *args):
+        assert len(self._inputs) == len(args)
+        for var, val in zip(self._inputs, args):
+            self[var] = val
+        self.compiled_updates['__call__']()
+        return [self[var] for var in self._dests]
+
+

--- a/nef/nef_theano/workspace.py
+++ b/nef/nef_theano/workspace.py
@@ -1,62 +1,103 @@
+import copy
 import sys
+
+import numpy as np
 
 import theano
 from theano.gof.vm import VM_Linker
+from theano.compile import deep_copy_op
+from theano.compile.pfunc import rebuild_collect_shared
 
 class CompiledUpdate(object):
-    def __init__(self, updated_vars, vals_memo, profiler=None,
+    def __init__(self, updated_vars, vals_memo, profiler=None, givens=None,
               **VM_Linker_kwargs):
         """
         updated_vars: sequence of (dst, expr) pairs
 
-        allow_gc - force the virtual machine to clean up unnecessary references,
-            in order to allow garbage collection on intermediate values during
-            computation of a function.
-
-        use_cloop - use the C-based virtual machine if possible
-
-        callback - a callable object to call after each call to a thunk within
-            the virtual machine.  It will be called with four arguments called
-            'node', 'thunk', 'storage_map', and 'compute_map'.
-
-        This object does *NOT* clone the expression graph, nor does it modify
-        the expression graph.
-
-        # XXX currently it does modify the expression graph because it creates an FGraph
-        # instance, but it should be changed to avoid this, because all it really needs
-        # the fgraph for is sorting.
+        This object may in future *NOT* clone the expression graph, and should
+        not modify the expression graph. For now though it may do both.
 
         """
 
+        # -- unique_outputs is used here to ensure that there is some
+        #    double-buffering going on, because actually dests and outputs can
+        #    include some of the same variables (e.g. swap values)
         dests, outputs = zip(*updated_vars)
-        inputs = theano.gof.graph.inputs(outputs + dests)
-        fgraph = theano.gof.FunctionGraph(inputs, outputs)
+        unique_outputs = map(deep_copy_op, outputs)
+
+        stuff = rebuild_collect_shared(
+            unique_outputs,
+            inputs=[],
+            replace=givens,
+            rebuild_strict=True,
+            copy_inputs_over=True)
+        # extracting the arguments
+        _inputs, unique_outputs_w_givens, other_stuff = stuff
+        clone_equiv1, _update_d, _update_expr, _shared_inputs = other_stuff
+
+        all_inputs = theano.gof.graph.inputs(unique_outputs_w_givens)
+
+        clone_equiv = {}
+        theano.gof.graph.clone_get_equiv(
+            all_inputs,
+            unique_outputs_w_givens,
+            copy_inputs_and_orphans=True,
+            memo=clone_equiv)
+        for orig_var in clone_equiv1:
+            clone_equiv[orig_var] = clone_equiv[clone_equiv1[orig_var]]
+        cloned_inputs = [clone_equiv[var] for var in all_inputs]
+        cloned_dests = [clone_equiv[var] for var in dests]
+        cloned_outputs = [clone_equiv[var] for var in unique_outputs_w_givens]
+        fgraph = theano.gof.fg.FunctionGraph(cloned_inputs, cloned_outputs)
+
+        for node in fgraph.apply_nodes:
+            if getattr(node.op, 'destroy_map', None):
+                if not accept_inplace:
+                    raise TypeError("Graph must not contain inplace operations", node, node.op)
+                else:
+                    fgraph.attach_feature(theano.gof.DestroyHandler())
+                    break
+
+        # We need to protect all immutable inputs from inplace operations.
+        fgraph.attach_feature(
+                theano.compile.function_module.Supervisor(invar
+                    for invar in cloned_inputs
+                    if not ((invar in cloned_dests) or
+                            (hasattr(fgraph, 'destroyers') and
+                                fgraph.destroyers(input)))))
+
+        # If named nodes are replaced, keep the name
+        for feature in theano.compile.function_module.std_fgraph.features:
+            fgraph.attach_feature(feature())
 
         #print 'inputs'
         #theano.printing.debugprint(inputs)
         #print 'outputs'
         #theano.printing.debugprint(outputs)
 
-        linker = VM_Linker(**VM_Linker_kwargs)
+        linker = VM_Linker(use_cloop=True, **VM_Linker_kwargs)
         linker.accept(fgraph, no_recycling=[])
-        linker.accept_var_updates(dict(updated_vars))
+        linker.accept_var_updates(dict(zip(cloned_dests, cloned_outputs)))
 
         input_storage = [vals_memo[i] if i in vals_memo else [i.data]
-                for i in inputs]
-        output_storage = [vals_memo[i] if i in vals_memo else [None]
-                for i in dests] # CAREFUL IS THIS OK?
+                for i in all_inputs]
+
+        theano.printing.debugprint(cloned_outputs)
+        theano.printing.debugprint(unique_outputs_w_givens)
 
         vm, input_containers, output_containers, thunks, order = linker.make_all(
             profiler=profiler,
             input_storage=input_storage,
-            output_storage=output_storage)
+            )
 
-        self.inputs = inputs
+        self.updated_vars = updated_vars
+        self.all_inputs = all_inputs
         self.outputs = outputs
+        self.unique_outputs = unique_outputs
+        self.clone_equiv = clone_equiv
         self.fgraph = fgraph
         self.vm = vm
         self.input_storage = input_storage
-        self.output_storage = output_storage
         self.input_containers = input_containers
         self.output_containers = output_containers
         self.thynks = thunks
@@ -71,7 +112,7 @@ class Workspace(object):
     """
     """
 
-    def __init__(self ):
+    def __init__(self):
         self.vals_memo = {}
         self.compiled_updates = {}
 
@@ -102,20 +143,94 @@ class Workspace(object):
     def run_update(self, key):
         self.compiled_updates[key]()
 
-    def optimize_memory_layout(self):
-        """
-        Potentially optimize the internal physical memory layout of variables
-        in order to run the compiled_updates faster.
 
-        This function generally invalidates any views into memory associated
-        with variables.
-        """
-        pass
+class SharedStorageWorkspace(Workspace):
+    def __init__(self, ws):
+        Workspace.__init__(self)
+
+        self.views_memo = {}
+
+        # set up some views
+        self.s_fvector = theano.tensor.vector('fvector')
+        vectors = [var for var in ws.vals_memo
+                if var.type == self.s_fvector.type]
+        if vectors:
+            fvector = np.concatenate(
+                    [ws.vals_memo[var][0] for var in vectors]).astype('float32')
+            offset = 0
+            for var in vectors:
+                self.views_memo[var] = (
+                        self.s_fvector,
+                        offset,
+                        len(ws.vals_memo[var][0]))
+                offset += len(ws.vals_memo[var][0])
+            self.vals_memo[self.s_fvector] = [fvector]
+
+        print self.views_memo
+
+        # set up some normal values
+        for var in ws.vals_memo:
+            if var not in self.views_memo:
+                self.vals_memo[var] = copy.deepcopy(ws.vals_memo[var])
+
+        for fname, f in ws.compiled_updates.items():
+            self.compile_update(fname, f.updated_vars)
+
+    def __contains__(self, key):
+        return key in self.vals_memo or key in self.views_memo
+
+    def __getitem__(self, key):
+        if key in self.views_memo:
+            var, offset, n = self.views_memo[key]
+            return self[var][offset: offset + n]
+        else:
+            return self.vals_memo[key][0]
+
+    def __setitem__(self, key, val):
+        filtered_val = key.type.filter(val, strict=False, allow_downcast=True)
+
+        if key in self.views_memo:
+            var, offset, n = self.views_memo[key]
+            self.vals_memo[var][0][offset: offset + n] = filtered_val
+        else:
+            if key in self.vals_memo:
+                self.vals_memo[key][0] = filtered_val
+            else:
+                self.vals_memo[key] = [filtered_val]
+
+    def compile_update(self, key, updated_vars):
+        new_s_fvector = self.s_fvector
+        no_view_updated_vars = []
+        for dst, out in updated_vars:
+            if dst in self.views_memo:
+                var, offset, n_elems = self.views_memo[dst]
+                assert var is self.s_fvector # XXX HACK
+                new_s_fvector = theano.tensor.set_subtensor(
+                        new_s_fvector[offset: offset + n_elems],
+                        out)
+            else:
+                no_view_updated_vars.append((dst, out))
+
+        if new_s_fvector != self.s_fvector:
+            no_view_updated_vars.append((self.s_fvector,
+                new_s_fvector))
+
+        givens = []
+        for var in self.views_memo:
+            svar, offset, n_elems = self.views_memo[var]
+            givens.append((var, svar[offset: offset + n_elems]))
+
+        cu = CompiledUpdate(no_view_updated_vars, self.vals_memo,
+                givens=givens)
+        self.compiled_updates[key] = cu
+        return cu
 
 
 class Function(Workspace):
     """
     Special case of Workspace for implementing a single callable expression
+
+    TODO: Provides support for structuring outputs as nested list, dict, etc.
     """
     def __init__(self, inputs, outputs):
         self._inputs = inputs


### PR DESCRIPTION
So what I'm calling "workspaces" have been on my radar for a long time for Theano as a way of simplifying the use of shared variables and eliminating hundreds (thousands??) of lines of crap in Theano.

The idea is to not have shared variables, instead have a workspace:

``` python
x = tensor.vector('x')
y = tensor.vector('y')

ws = Workspace()
ws[x] = [1, 2]
ws[y] = [3, 4]
ws.compile_update('f', [
        (x, 2 * x),
        (y, x + y)])

assert np.allclose([ws[x], ws[y]],[[1, 2], [3, 4]])

# compute stuff
ws.run_update('f')
assert np.allclose([ws[x], ws[y]],[[2, 4], [4, 6]])

# trigger graph optimizations
# and potentially rearrange the layout of variables in physical memory
# copy over the values of the variables if they have moved
ws.optimize_memory_layout(device='gpu')

# now run a freshly-compiled function that is running on the GPU
ws.run_update('f')

# bring the value back from wherever it is (like shared.get_value())
print ws[x]

```

The reason to use this mechanism is so that
- an easily-debugged version of math can be built and run in the default workspace
- this basic workspace is something that we can pickle properly
- optimized workspaces can be converted back to simple ones for saving
- being able to "jointly" optimize functions based on runtime statistics is a big win, because Theano's shape inference is not strong
- **crucial for nef-py** the optimize_memory_layout function can merge together the ensemble state information so that large numbers of ensembles can be evaluated without large numbers of graph nodes

This last point follows up on recent discussion of how to conglomerate the state information across ensembles (and create ensemble views etc.) for the purpose of running models fast. It wouldn't be the same thing as making ensembles all views, but it would allow us to get fast implementations of the _current_ type of ensemble, namely, the kind that appears to manage its own memory.
