### PR TITLE
moved connection logic into connection Ops

### DIFF
--- a/nengo/nef_theano/connection.py
+++ b/nengo/nef_theano/connection.py
@@ -1,0 +1,124 @@
+import theano
+import numpy as np
+
+def compute_transform(dim_pre, dim_post, array_size, weight=1,
+                      index_pre=None, index_post=None, transform=None):
+    """Helper function used by :func:`nef.Network.connect()` to create
+    the `dim_post` by `dim_pre` transform matrix.
+
+    Values are either 0 or *weight*. *index_pre* and *index_post*
+    are used to determine which values are non-zero, and indicate
+    which dimensions of the pre-synaptic ensemble should be routed
+    to which dimensions of the post-synaptic ensemble.
+
+    :param int dim_pre: first dimension of transform matrix
+    :param int dim_post: second dimension of transform matrix
+    :param int array_size: size of the network array
+    :param float weight: the non-zero value to put into the matrix
+    :param index_pre: the indexes of the pre-synaptic dimensions to use
+    :type index_pre: list of integers or a single integer
+    :param index_post:
+        the indexes of the post-synaptic dimensions to use
+    :type index_post: list of integers or a single integer
+    :returns:
+        a two-dimensional transform matrix performing
+        the requested routing
+
+    """
+
+    if transform is None:
+        # create a matrix of zeros
+        transform = [[0] * dim_pre for i in range(dim_post * array_size)]
+
+        # default index_pre/post lists set up *weight* value
+        # on diagonal of transform
+
+        # if dim_post * array_size != dim_pre,
+        # then values wrap around when edge hit
+        if index_pre is None:
+            index_pre = range(dim_pre)
+        elif isinstance(index_pre, int):
+            index_pre = [index_pre]
+        if index_post is None:
+            index_post = range(dim_post * array_size)
+        elif isinstance(index_post, int):
+            index_post = [index_post]
+
+        for i in range(max(len(index_pre), len(index_post))):
+            pre = index_pre[i % len(index_pre)]
+            post = index_post[i % len(index_post)]
+            transform[post][pre] = weight
+
+    transform = np.array(transform)
+
+    # reformulate to account for post.array_size
+    if transform.shape == (dim_post * array_size, dim_pre):
+
+
+    return transform
+
+
+class Case1(theano.Op):
+    """
+    XXX doc: see network.py for why this is called case1
+    """
+    def __init__(self, shape4):
+        self.shape4 = shape4
+
+    def __hash__(self):
+        return hash(type(self), self.shape4)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.shape4 == other.shape4
+
+    def make_node(self, transform, pre_output):
+        return theano.Apply(self,
+                [transform, pre_output],
+                [tensor.matrix()])
+
+    def perform(self, node, inputs, outstor):
+        transform, pre_output = inputs
+        # TODO: implement with np.dot
+        encoded_output = (transform.reshape(self.shape4)
+            * pre_output.reshape(self.shape4[2:]))
+
+        # sum the contribution from all pre neurons
+        # for each post neuron
+        encoded_output = np.sum(encoded_output, axis=3)
+        # sum the contribution from each of the
+        # pre arrays for each post neuron
+        encoded_output = np.sum(encoded_output, axis=2)
+        # reshape to get rid of the extra dimension
+        encoded_output.shape = self.shape4[:2]
+        outstor[0][0] = encoded_output
+
+
+class Case2(theano.Op):
+    """
+    XXX doc: see network.py for why this is called case2
+    """
+    def __init__(self, shape4):
+        self.shape4 = shape4
+
+    def __hash__(self):
+        return hash(type(self), self.shape4)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.shape4 == other.shape4
+
+    def make_node(self, transform, pre_output):
+        return theano.Apply(self,
+                [transform, pre_output],
+                [tensor.matrix()])
+
+    def perform(self, node, inputs, outstor):
+        transform, pre_output = inputs
+        post_array_size, post_neurons_num = self.shape4[:2]
+        pre_array_size, pre_neurons_num = self.shape4[2:]
+
+        encoded_output = np.zeros((post_array_size, post_neurons_num),
+                dtype=node.outputs[0].dtype)
+        for ii in xrange(post_neurons_num):
+            encoded_output[:, ii] = np.dot(transform[:, ii], pre_output)
+        outstor[0][0] = encoded_output
+

--- a/nengo/nef_theano/connection.py
+++ b/nengo/nef_theano/connection.py
@@ -53,7 +53,14 @@ def compute_transform(dim_pre, dim_post, array_size, weight=1,
 
     # reformulate to account for post.array_size
     if transform.shape == (dim_post * array_size, dim_pre):
+        array_transform = [[[0] * dim_pre for i in range(dim_post)]
+                           for j in range(array_size)]
 
+        for i in range(array_size):
+            for j in range(dim_post):
+                array_transform[i][j] = transform[i * dim_post + j]
+
+        transform = array_transform
 
     return transform
 

--- a/nengo/nef_theano/network.py
+++ b/nengo/nef_theano/network.py
@@ -12,6 +12,7 @@ from . import probe
 from . import origin
 from . import input
 from . import subnetwork
+from . import connection
 
 class Network(object):
     def __init__(self, name, seed=None, fixed_seed=None, dt=.001):
@@ -58,69 +59,6 @@ class Network(object):
         self.tick_nodes.append(node)
         self.nodes[node.name] = node
 
-    def compute_transform(self, dim_pre, dim_post, array_size, weight=1,
-                          index_pre=None, index_post=None, transform=None):
-        """Helper function used by :func:`nef.Network.connect()` to create
-        the `dim_post` by `dim_pre` transform matrix.
-
-        Values are either 0 or *weight*. *index_pre* and *index_post*
-        are used to determine which values are non-zero, and indicate
-        which dimensions of the pre-synaptic ensemble should be routed
-        to which dimensions of the post-synaptic ensemble.
-
-        :param int dim_pre: first dimension of transform matrix
-        :param int dim_post: second dimension of transform matrix
-        :param int array_size: size of the network array
-        :param float weight: the non-zero value to put into the matrix
-        :param index_pre: the indexes of the pre-synaptic dimensions to use
-        :type index_pre: list of integers or a single integer
-        :param index_post:
-            the indexes of the post-synaptic dimensions to use
-        :type index_post: list of integers or a single integer
-        :returns:
-            a two-dimensional transform matrix performing
-            the requested routing
-
-        """
-
-        if transform is None:
-            # create a matrix of zeros
-            transform = [[0] * dim_pre for i in range(dim_post * array_size)]
-
-            # default index_pre/post lists set up *weight* value
-            # on diagonal of transform
-            
-            # if dim_post * array_size != dim_pre,
-            # then values wrap around when edge hit
-            if index_pre is None:
-                index_pre = range(dim_pre) 
-            elif isinstance(index_pre, int):
-                index_pre = [index_pre] 
-            if index_post is None:
-                index_post = range(dim_post * array_size) 
-            elif isinstance(index_post, int):
-                index_post = [index_post]
-
-            for i in range(max(len(index_pre), len(index_post))):
-                pre = index_pre[i % len(index_pre)]
-                post = index_post[i % len(index_post)]
-                transform[post][pre] = weight
-
-        transform = np.array(transform)
-
-        # reformulate to account for post.array_size
-        if transform.shape == (dim_post * array_size, dim_pre):
-
-            array_transform = [[[0] * dim_pre for i in range(dim_post)]
-                               for j in range(array_size)]
-
-            for i in range(array_size):
-                for j in range(dim_post):
-                    array_transform[i][j] = transform[i * dim_post + j]
-
-            transform = array_transform
-
-        return transform
         
     def connect(self, pre, post, transform=None, weight=1,
                 index_pre=None, index_post=None, pstc=0.01, 
@@ -172,17 +110,17 @@ class Network(object):
         :param index_pre:
             The indexes of the pre-synaptic dimensions to use.
             Ignored if *transform* is not None.
-            See :func:`nef.Network.compute_transform()`
+            See :func:`connection.compute_transform()`
         :param float weight:
             Scaling factor for a transformation defined with
             *index_pre* and *index_post*.
             Ignored if *transform* is not None.
-            See :func:`nef.Network.compute_transform()`
+            See :func:`connection.compute_transform()`
         :type index_pre: List of integers or a single integer
         :param index_post:
             The indexes of the post-synaptic dimensions to use.
             Ignored if *transform* is not None.
-            See :func:`nef.Network.compute_transform()`
+            See :func:`connection.compute_transform()`
         :type index_post: List of integers or a single integer 
         :param function func:
             Function to be computed by this connection.
@@ -261,24 +199,14 @@ class Network(object):
                     assert transform.shape == \
                             (post.array_size, post.neurons_num, 
                              pre.array_size, pre.neurons_num)
-                    
+
                     # get spiking output from pre population
                     pre_output = pre.neurons.output 
 
-                    encoded_output = TT.mul( 
-                        TT.reshape(transform, (post.array_size, post.neurons_num, 
-                        pre.array_size, pre.neurons_num)), TT.reshape(pre_output, 
-                        (pre.array_size, pre.neurons_num)) )
-
-                    # sum the contribution from all pre neurons 
-                    # for each post neuron 
-                    encoded_output = TT.sum(encoded_output, axis=3)
-                    # sum the contribution from each of the 
-                    # pre arrays for each post neuron
-                    encoded_output = TT.sum(encoded_output, axis=2)
-                    # reshape to get rid of the extra dimension
-                    encoded_output = TT.reshape(encoded_output, 
-                        (post.array_size, post.neurons_num))
+                    case1 = connection.Case1(
+                        (post_array_size, post.neurons_num,
+                         pre.array_size, pre.neurons_num))
+                    encoded_output = case1(transform, pre_output)
 
                     # pass in the pre population encoded output function
                     # to the post population, connecting them for theano
@@ -293,16 +221,12 @@ class Network(object):
                     
                     # can't specify a function with either side encoded connection
                     assert func == None 
+
+                    case2 = connection.Case2(
+                        (post_array_size, post.neurons_num,
+                         pre.array_size, pre.neurons_num))
+                    encoded_output = case2(transform, pre_output)
     
-                    pre_output = TT.stack([pre_output] * post.neurons_num)
-                    encoded_output = TT.batched_dot( TT.reshape(transform, 
-                        (post.array_size, post.neurons_num, dim_pre)),
-                        TT.reshape(pre_output, (post.neurons_num, dim_pre, 1)) )
-    
-                    # at this point encoded output should be 
-                    # (post.array_size x post.neurons_num x 1)
-                    encoded_output = TT.reshape(encoded_output, 
-                        (post.array_size, post.neurons_num))
                     # pass in the pre population encoded output function
                     # to the post population, connecting them for theano
                     post.add_termination(name=pre_name, pstc=pstc, 
@@ -312,7 +236,7 @@ class Network(object):
         
         # if decoded-decoded connection (case 1)
         # compute transform if not given, if given make sure shape is correct
-        transform = self.compute_transform(
+        transform = connection.compute_transform(
             dim_pre=dim_pre,
             dim_post=post.dimensions,
             array_size=post.array_size,


### PR DESCRIPTION
If we move connection logic into their own Ops, then high level graph manipulation becomes a lot easier.  This PR doesn't have that manipulation code, but it moves some of the theano reshaping & stacking etc. from network.py into the body of new Ops in connection.py
