### PR TITLE
Fix breaking API change in Theano 0.6

### DIFF
--- a/nengo_theano/ensemble.py
+++ b/nengo_theano/ensemble.py
@@ -363,7 +363,7 @@ class Ensemble:
                 # represented input signal x preferred direction
 
                 for i in range(self.array_size): #len(self.bias)):
-                    J = TT.basic.inc_subtensor(J[i], 
+                    J = TT.inc_subtensor(J[i], 
                         TT.dot(X[i], self.shared_encoders[i].T))
 
             # if noise has been specified for this neuron,

--- a/nengo_theano/ensemble_origin.py
+++ b/nengo_theano/ensemble_origin.py
@@ -231,7 +231,7 @@ class EnsembleOrigin(Origin):
 
         z = TT.zeros((self.ensemble.array_size, self.func_size), dtype='float32')
         for i in range(self.ensemble.array_size):
-            z = TT.basic.set_subtensor(z[i], r / dt * TT.dot(spikes[i], 
+            z = TT.set_subtensor(z[i], r / dt * TT.dot(spikes[i], 
                 self.decoders_shuffled[i].T)) 
 
         return OrderedDict({self.decoded_output: TT.flatten(z)})

--- a/nengo_theano/network.py
+++ b/nengo_theano/network.py
@@ -285,7 +285,7 @@ class Network(object):
         encoded_output = TT.zeros((post.array_size, post.neurons_num),
                                    dtype='float32')
         for ii in xrange(post.neurons_num):
-            encoded_output = TT.basic.set_subtensor(encoded_output[:, ii],
+            encoded_output = TT.set_subtensor(encoded_output[:, ii],
                  TT.dot(weight_matrix[:, ii], pre_output))
 
         # pass in the pre population encoded output function


### PR DESCRIPTION
Theano 0.6 moved subtensor operations from `tensor.basic.*` to `tensor.*`.
